### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tests/raw-samples"]
 	path = tests/raw-samples
-	url = git://gitorious.org/taglib-sharp/raw-samples.git
+	url = https://gitorious.org/taglib-sharp/raw-samples.git


### PR DESCRIPTION
It appears that ssh access is not longer enabled for the gitorious repository. This is causing the build on TeamCity to fail.